### PR TITLE
change course organisers

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -38,11 +38,11 @@ Wrap-up slides are available [here](slides/Lecture_11_WrappingUp.pdf).
 
 ## Who we are
 
-Your course organisers are [Oliver Brady](https://www.lshtm.ac.uk/aboutus/people/brady.oliver), [Nicholas Davies](https://www.lshtm.ac.uk/aboutus/people/davies.nicholas), and [Yang Liu](https://www.lshtm.ac.uk/aboutus/people/liu.yang).
+Your course organisers are [Katie Atkins](https://www.lshtm.ac.uk/aboutus/people/atkins.katie), [Nicholas Davies](https://www.lshtm.ac.uk/aboutus/people/davies.nicholas), [Roz Eggo](https://www.lshtm.ac.uk/aboutus/people/eggo.rosalind), and [Kaitlyn Johnson](https://www.lshtm.ac.uk/aboutus/people/johnson.kaitlyn).
 
 Your course administrator is Francesco Grisolia.
 
-Other lecturers and demonstrators are (in alphabetical order): [Kaja Abbas](https://www.lshtm.ac.uk/aboutus/people/abbas.kaja), [Johnny Filipe](https://www.lshtm.ac.uk/aboutus/people/nogueira-filipe.johnny), [Seb Funk](https://www.lshtm.ac.uk/aboutus/people/funk.sebastian), [Kath O'Reilly](https://www.lshtm.ac.uk/aboutus/people/oreilly.kathleen), [Billy Quilty](https://www.lshtm.ac.uk/aboutus/people/quilty.billy), [Alex Richards](https://www.lshtm.ac.uk/aboutus/people/richards.alexandra), [Alexis Robert](https://www.lshtm.ac.uk/aboutus/people/robert.alexis).
+Other lecturers and demonstrators are (in alphabetical order): [Kaja Abbas](https://www.lshtm.ac.uk/aboutus/people/abbas.kaja), [Sam Abbott](https://www.lshtm.ac.uk/aboutus/people/abbott.sam), and [Alexis Robert](https://www.lshtm.ac.uk/aboutus/people/robert.alexis).
 
 ## Who you are
 


### PR DESCRIPTION
This changes the index.qmd file to add the course organiser (ABC order) and instructors -- I attempted to rerender with `quarto::quarto_render()` but ran into an issue locally.